### PR TITLE
Fine-tune jumping/ducking thresholds

### DIFF
--- a/Movenet/README.md
+++ b/Movenet/README.md
@@ -14,8 +14,10 @@ pip install --upgrade tensorflow-estimator==2.6.0
 
 2. Download movenet thunder and/or lightning TFLite model:
 
-- [Thunder](https://tfhub.dev/google/movenet/singlepose/thunder/4)
-- [Lightning](https://tfhub.dev/google/movenet/singlepose/lightning/4)
+- [Lightning](https://tfhub.dev/google/lite-model/movenet/singlepose/lightning/3)
+- [Thunder](https://tfhub.dev/google/lite-model/movenet/singlepose/thunder/3)
+
+Lightning prioritizes latency, while thunder prioritizes model accuracy.
 
 3. Add the model to the Movenet/models directory.
 
@@ -24,6 +26,8 @@ pip install --upgrade tensorflow-estimator==2.6.0
 1. Run position tracking for obstacle navigation
 
 `python3 position_tracking.py --no-mqtt -m [thunder|lightning]`
+
+The model (m) argument allows you to select the model (thunder/lightning), and the no-mqtt argument sets up the program so that the player movement data is not sent to Unity with MQTT. By default (no args), the lightning model is used, and player movement is sent to Unity.
 
 2. Run data collection
 
@@ -38,7 +42,7 @@ and sending data to Unity over MQTT.
 
 2. movenet.py
 
-Movenet class for detecting pose keypoints using tensorflow movenet
+Movenet class for detecting pose keypoints using tensorflow movenet.
 
 3. publisher.py
 
@@ -46,22 +50,26 @@ MQTT publisher class.
 
 4. movement_recognizer.py
 
-Stores previous $max_frames keypoints and outputs whether player is
+Stores previous $max_keypoints keypoints and outputs whether player is
 jumping, ducking, out of frame, or stationary.
 
-5. keypoints_filter.py
+5. keypoints.py
+
+Keypoints class to encapsulate logic for extracting body part coords.
+
+6. keypoints_filter.py
 
 Apply one-euro filter to x and y coords in keypoints.
 
-6. one_euro_filter.py
+7. one_euro_filter.py
 
 One-euro filter class.
 
-7. enums.py
+8. enums.py
 
 Enums for player position and mapping from body part to keypoint index.
 
-8. collect_data.py
+9. collect_data.py
 
 Collect data for tuning position tracking model.
 

--- a/Movenet/src/enums.py
+++ b/Movenet/src/enums.py
@@ -33,3 +33,8 @@ class Position(Enum):
     DUCKING = 5
     OUT_OF_FRAME = 6
     STATIONARY = 7
+    # transition from duck to stationary (tell Unity to stop ducking)
+    DUCK_STATIONARY = 8
+    # transition from out-of-frame to stationary
+    # (tell Unity to stop out-of-frame message)
+    OUT_FRAME_STATIONARY = 9

--- a/Movenet/src/keypoints.py
+++ b/Movenet/src/keypoints.py
@@ -1,0 +1,60 @@
+import numpy as np
+from enums import BodyPart
+
+"""Class for encapsulating extracting body part keypoints"""
+
+
+class Keypoints:
+    def __init__(self, keypoints: np.ndarray) -> None:
+        self._keypoints = keypoints
+
+    def keypoints(self):
+        return self._keypoints
+
+    def get(self, body_part: BodyPart) -> np.ndarray:
+        """get keypoint by body part"""
+        return self._keypoints[body_part.value]
+
+    def get_x(self, body_part: BodyPart) -> float:
+        """get x coord"""
+        return self.get(body_part)[1]
+
+    def get_y(self, body_part: BodyPart) -> float:
+        """get y coord"""
+        return self.get(body_part)[0]
+
+    def get_conf(self, body_part: BodyPart) -> float:
+        """get confidence"""
+        return self.get(body_part)[2]
+
+    def head_visible(self, conf_threshold: float = 0.3) -> bool:
+        left_eye_visible = self.body_part_visible(BodyPart.LEFT_EYE, conf_threshold)
+        right_eye_visible = self.body_part_visible(BodyPart.RIGHT_EYE, conf_threshold)
+        left_ear_visible = self.body_part_visible(BodyPart.LEFT_EAR, conf_threshold)
+        right_ear_visible = self.body_part_visible(BodyPart.RIGHT_EAR, conf_threshold)
+        return (
+            left_eye_visible
+            and right_eye_visible
+            and left_ear_visible
+            and right_ear_visible
+        )
+
+    def hips_visible(self, conf_threshold: float = 0.3) -> bool:
+        left_hip_visible = self.body_part_visible(BodyPart.LEFT_HIP, conf_threshold)
+        right_hip_visible = self.body_part_visible(BodyPart.RIGHT_HIP, conf_threshold)
+        return left_hip_visible and right_hip_visible
+
+    def shoulders_visible(self, conf_threshold: float = 0.3) -> bool:
+        left_shoulder_visible = self.body_part_visible(
+            BodyPart.LEFT_SHOULDER, conf_threshold
+        )
+        right_shoulder_visible = self.body_part_visible(
+            BodyPart.RIGHT_SHOULDER, conf_threshold
+        )
+        return left_shoulder_visible and right_shoulder_visible
+
+    def body_part_visible(
+        self, body_part: BodyPart, conf_threshold: float = 0.3
+    ) -> bool:
+        _, _, conf = self._keypoints[body_part.value]
+        return conf >= conf_threshold

--- a/Movenet/src/movement_recognizer.py
+++ b/Movenet/src/movement_recognizer.py
@@ -1,4 +1,5 @@
-from enums import Position, BodyPart
+from enums import Position as Pos, BodyPart as BP
+from keypoints import Keypoints
 import numpy as np
 import time
 
@@ -9,7 +10,6 @@ based on body keypoint data
 
 """
 TODO:
-- code cleanup and documentation
 - fine-tuning model for accuracy
 
 Current Issues:
@@ -24,17 +24,19 @@ class MovementRecognizer:
     def __init__(self, max_keypoints: int = 150) -> None:
         """
         Props:
-          max_keypoints: max number of keypoints to store
-          keypoints_data: list of last $max_keypoints keypoints
+          max_keypoints (int): max number of sequential keypoints to store
+          keypoints_data (List[Keypoints]): last $max_keypoints keypoints
+          position (Pos): current player position
+          last_pos_update (float): time of last position update (secs)
+          prev_coords (Keypoints): averaged keypoints before jump/duck
         """
         self.max_keypoints = max_keypoints
         self.keypoints_data = list()
-        self.position = Position.STATIONARY
+        self.position = Pos.STATIONARY
         self.last_pos_update = time.time()
-        self.prev_hips = None
-        self.prev_shoulders = None
+        self.prev_coords = None
 
-    def add_and_recognize(self, keypoints: np.ndarray) -> Position:
+    def add_and_recognize(self, keypoints: np.ndarray) -> Pos:
         """ Add keypoints to keypoints_data and recognize player movement
         Args:
           keypoints: predicted body keypoints of shape [17, 3]
@@ -45,41 +47,37 @@ class MovementRecognizer:
         return self._recognize()
 
     def _add(self, keypoints: np.ndarray) -> None:
-        """ Add new keypoint sample; ensure < $max_keypoint samples
+        """ Add new keypoint sample; ensure < $max_keypoint total samples
         Args:
           keypoints: predicted body keypoints of shape [17, 3]
         """
-        self.keypoints_data.append(keypoints)
+        self.keypoints_data.append(Keypoints(keypoints))
         if len(self.keypoints_data) > self.max_keypoints:
             self.keypoints_data.pop(0)
 
     def _set_prev_coords(self):
+        """ Store averaged coords before jumping/ducking
+            Used to determine if player has returned to stationary position
+        """
         if len(self.keypoints_data) > 10:
             samples = self.keypoints_data[-10:]
         else:
             samples = self.keypoints_data
-        shoulders_avg = np.array([0.0, 0.0])
-        hips_avg = np.array([0.0, 0.0])
-        for s in samples:
-            s_lshoulder = s[BodyPart.LEFT_SHOULDER.value][0]
-            s_rshoulder = s[BodyPart.RIGHT_SHOULDER.value][0]
-            shoulders_avg[0] += s_lshoulder
-            shoulders_avg[1] += s_rshoulder
-            s_lhip = s[BodyPart.LEFT_HIP.value][0]
-            s_rhip = s[BodyPart.RIGHT_HIP.value][0]
-            hips_avg[0] += s_lhip
-            hips_avg[1] += s_rhip
-        self.prev_hips = hips_avg / len(samples)
-        self.prev_shoulders = shoulders_avg / len(samples)
+        self.prev_coords = Keypoints(np.mean([s.keypoints() for s in samples], axis=0))
 
-    def _within_threshold(self, threshold=0.05):
-        # lh_prev, rh_prev = self.prev_hips
-        ls_prev, rs_prev = self.prev_shoulders
-        ls_curr = self.keypoints_data[-1][BodyPart.LEFT_SHOULDER.value][0]
-        rs_curr = self.keypoints_data[-1][BodyPart.RIGHT_SHOULDER.value][0]
+    def _stationary_recognized(self, threshold=0.05):
+        """Determine if player has returned to stationary after jump/duck
+          Current Condition:
+            Shoulder keypoints are within $threshold of keypoints before jump/duck
+            (averaged over 10 samples in _set_prev_coords function)
+        """
+        ls_prev = self.prev_coords.get_y(BP.LEFT_SHOULDER)
+        rs_prev = self.prev_coords.get_y(BP.RIGHT_SHOULDER)
+        ls_curr = self.keypoints_data[-1].get_y(BP.LEFT_SHOULDER)
+        rs_curr = self.keypoints_data[-1].get_y(BP.RIGHT_SHOULDER)
         return abs(ls_prev - ls_curr) < threshold and abs(rs_prev - rs_curr) < threshold
 
-    def _recognize(self) -> Position:
+    def _recognize(self) -> Pos:
         """ Recognize player position
         Returns:
           Position enum depicting whether player is
@@ -88,33 +86,49 @@ class MovementRecognizer:
         next_pos = self.position
 
         if self._player_out_of_frame():
-            next_pos = Position.OUT_OF_FRAME
-        elif self.position == Position.OUT_OF_FRAME:
-            next_pos = Position.STATIONARY
+            next_pos = Pos.OUT_OF_FRAME
+        elif self.position == Pos.OUT_OF_FRAME:
+            next_pos = Pos.OUT_FRAME_STATIONARY
 
-        if self.position == Position.STATIONARY:
+        if self.position == Pos.STATIONARY:
+            # avoid quick state update (< 0.3 seconds)
+            # prevents jump registered after duck
             if time.time() - self.last_pos_update < 0.3:
                 return self.position
+            # check for jump/duck
             if self._jump_recognized():
-                next_pos = Position.JUMP_START
+                next_pos = Pos.JUMP_START
                 self._set_prev_coords()
             elif self._duck_recognized():
-                next_pos = Position.DUCK_START
+                next_pos = Pos.DUCK_START
                 self._set_prev_coords()
-        elif self.position == Position.DUCK_START:
-            next_pos = Position.DUCKING
-        elif self.position == Position.JUMP_START:
-            next_pos = Position.JUMPING
-        elif self.position == Position.JUMPING:
-            if self._within_threshold():
-                next_pos = Position.STATIONARY
+
+        if self.position == Pos.DUCK_START:
+            next_pos = Pos.DUCKING
+        elif self.position == Pos.JUMP_START:
+            next_pos = Pos.JUMPING
+
+        if self.position == Pos.JUMPING:
+            if self._stationary_recognized():
+                next_pos = Pos.STATIONARY
+            # jump should not last longer than 0.7 s
+            # prevent false positive never returning to stationary
             if time.time() - self.last_pos_update >= 0.7:
-                next_pos = Position.STATIONARY
-        elif self.position == Position.DUCKING:
-            if self._within_threshold():
-                next_pos = Position.STATIONARY
+                next_pos = Pos.STATIONARY
+        elif self.position == Pos.DUCKING:
+            if self._stationary_recognized():
+                next_pos = Pos.STATIONARY
+            # duck unlikely to last longer than 5 s
+            # prevent false position never returning to stationary
             if time.time() - self.last_pos_update >= 5:
-                next_pos = Position.STATIONARY
+                next_pos = Pos.STATIONARY
+
+        if (
+            self.position == Pos.DUCK_STATIONARY
+            or self.position == Pos.OUT_FRAME_STATIONARY
+        ):
+            next_pos = Pos.STATIONARY
+
         if next_pos != self.position:
             self.position = next_pos
             self.last_pos_update = time.time()
@@ -122,9 +136,10 @@ class MovementRecognizer:
         return self.position
 
     def _jump_recognized(self) -> bool:
-        """ Determine if player is jumping
+        """ Determine if player has started jumping
         Current condition: 
-          left shoulder keypoint is on top half of frame
+          Left shoulder is 0.1 higher than 5th-last sample
+          (and confidence is > 0.3)
         Returns:
           True if player is jumping; False o.w.
         """
@@ -132,8 +147,8 @@ class MovementRecognizer:
             return False
         last_sample = self.keypoints_data[-1]
         fifth_last_sample = self.keypoints_data[-5]
-        y1, _, c1 = last_sample[BodyPart.LEFT_SHOULDER.value]
-        y2, _, c2 = fifth_last_sample[BodyPart.LEFT_SHOULDER.value]
+        y1, _, c1 = last_sample.get(BP.LEFT_SHOULDER)
+        y2, _, c2 = fifth_last_sample.get(BP.LEFT_SHOULDER)
         if c1 < 0.3 or c2 < 0.3:
             return False
         return y2 - y1 >= 0.1
@@ -141,7 +156,8 @@ class MovementRecognizer:
     def _duck_recognized(self) -> bool:
         """ Determine if player is ducking
         Current condition: 
-          left shoulder keypoint is on bottom 40% of frame
+          Left shoulder is 0.1 lower than 5-th last sample
+          (and confience is > 0.3)
         Returns:
           True if player is ducking; False o.w.
         """
@@ -149,27 +165,16 @@ class MovementRecognizer:
             return False
         last_sample = self.keypoints_data[-1]
         fifth_last_sample = self.keypoints_data[-5]
-        y1, _, c1 = last_sample[BodyPart.LEFT_SHOULDER.value]
-        y2, _, c2 = fifth_last_sample[BodyPart.LEFT_SHOULDER.value]
+        y1, _, c1 = last_sample.get(BP.LEFT_SHOULDER)
+        y2, _, c2 = fifth_last_sample.get(BP.LEFT_SHOULDER)
         if c1 < 0.3 or c2 < 0.3:
             return False
         return y1 - y2 >= 0.1
 
-    def _duck_up_recognized(self) -> bool:
-        if len(self.keypoints_data) < 5:
-            return False
-        last_sample = self.keypoints_data[-1]
-        fifth_last_sample = self.keypoints_data[-5]
-        y1, _, c1 = last_sample[BodyPart.LEFT_SHOULDER.value]
-        y2, _, c2 = fifth_last_sample[BodyPart.LEFT_SHOULDER.value]
-        if c1 < 0.3 or c2 < 0.3:
-            return False
-        return y1 - y2 <= 0.04
-
     def _player_out_of_frame(self) -> bool:
         """ Determine if player is out of frame
         Current condition: 
-          shoulders or hips must be in frame within the last 3 samples
+          Shoulders must be in frame within the last 3 samples
         Returns:
           True if player is out-of-frame; False o.w.
         """
@@ -177,33 +182,7 @@ class MovementRecognizer:
             return False
         last_5_samples = self.keypoints_data[-5:]
         for sample in last_5_samples:
-            shoulders_visible = self._shoulders_visible(sample)
+            shoulders_visible = sample.shoulders_visible()
             if shoulders_visible:
                 return False
         return True
-
-    def _hips_visible(self, keypoint: np.ndarray, conf_threshold: float = 0.3) -> bool:
-        left_hip_visible = self._body_part_visible(
-            keypoint, BodyPart.LEFT_HIP, conf_threshold
-        )
-        right_hip_visible = self._body_part_visible(
-            keypoint, BodyPart.RIGHT_HIP, conf_threshold
-        )
-        return left_hip_visible and right_hip_visible
-
-    def _shoulders_visible(
-        self, keypoint: np.ndarray, conf_threshold: float = 0.3
-    ) -> bool:
-        left_shoulder_visible = self._body_part_visible(
-            keypoint, BodyPart.LEFT_SHOULDER, conf_threshold
-        )
-        right_shoulder_visible = self._body_part_visible(
-            keypoint, BodyPart.RIGHT_SHOULDER, conf_threshold
-        )
-        return left_shoulder_visible and right_shoulder_visible
-
-    def _body_part_visible(
-        self, keypoint: np.ndarray, body_part: BodyPart, conf_threshold: float = 0.3
-    ) -> bool:
-        _, _, conf = keypoint[body_part.value]
-        return conf >= conf_threshold

--- a/Movenet/src/movement_recognizer.py
+++ b/Movenet/src/movement_recognizer.py
@@ -13,10 +13,17 @@ TODO:
 - fine-tuning model for accuracy
 
 Current Issues:
-- requires high ducking speed for recognition
-- moving up after duck sometimes gets recognized as jump
-- slight duck before jump sometimes recognized as duck
-- fast player movement forwards sometimes recognized as jump
+- moving up after duck sometimes gets recognized as jump (mostly resolved)
+- slight duck before jump sometimes recognized as duck (mostly resolved)
+- fast forwards movement sometimes recognized as jump
+- fast backwards movement sometimes recognized as duck
+- average more visible keypoints to avoid noise
+- occasionally very fast duck does not return to stationary 
+  (very unlikely player will be ducking quickly)
+
+Future plans: 
+- use x coord to differentiate between jump/duck and moving forward/backward quickly
+- average over more visible body parts to reduce noise
 """
 
 
@@ -59,13 +66,13 @@ class MovementRecognizer:
         """ Store averaged coords before jumping/ducking
             Used to determine if player has returned to stationary position
         """
-        if len(self.keypoints_data) > 10:
-            samples = self.keypoints_data[-10:]
+        if len(self.keypoints_data) > 15:
+            samples = self.keypoints_data[-15:-5]
         else:
             samples = self.keypoints_data
         self.prev_coords = Keypoints(np.mean([s.keypoints() for s in samples], axis=0))
 
-    def _stationary_recognized(self, threshold=0.05):
+    def _stationary_recognized(self, threshold=0.015):
         """Determine if player has returned to stationary after jump/duck
           Current Condition:
             Shoulder keypoints are within $threshold of keypoints before jump/duck
@@ -93,7 +100,7 @@ class MovementRecognizer:
         if self.position == Pos.STATIONARY:
             # avoid quick state update (< 0.3 seconds)
             # prevents jump registered after duck
-            if time.time() - self.last_pos_update < 0.3:
+            if time.time() - self.last_pos_update < 0.5:
                 return self.position
             # check for jump/duck
             if self._jump_recognized():
@@ -117,11 +124,11 @@ class MovementRecognizer:
                 next_pos = Pos.STATIONARY
         elif self.position == Pos.DUCKING:
             if self._stationary_recognized():
-                next_pos = Pos.STATIONARY
+                next_pos = Pos.DUCK_STATIONARY
             # duck unlikely to last longer than 5 s
             # prevent false position never returning to stationary
             if time.time() - self.last_pos_update >= 5:
-                next_pos = Pos.STATIONARY
+                next_pos = Pos.DUCK_STATIONARY
 
         if (
             self.position == Pos.DUCK_STATIONARY
@@ -138,7 +145,7 @@ class MovementRecognizer:
     def _jump_recognized(self) -> bool:
         """ Determine if player has started jumping
         Current condition: 
-          Left shoulder is 0.1 higher than 5th-last sample
+          Left shoulder is 0.3 higher than 5th-last sample
           (and confidence is > 0.3)
         Returns:
           True if player is jumping; False o.w.
@@ -151,30 +158,30 @@ class MovementRecognizer:
         y2, _, c2 = fifth_last_sample.get(BP.LEFT_SHOULDER)
         if c1 < 0.3 or c2 < 0.3:
             return False
-        return y2 - y1 >= 0.1
+        return y2 - y1 >= 0.3
 
     def _duck_recognized(self) -> bool:
         """ Determine if player is ducking
         Current condition: 
-          Left shoulder is 0.1 lower than 5-th last sample
+          Left shoulder is 0.2 lower than 10-th last sample
           (and confience is > 0.3)
         Returns:
           True if player is ducking; False o.w.
         """
-        if len(self.keypoints_data) < 5:
+        if len(self.keypoints_data) < 10:
             return False
         last_sample = self.keypoints_data[-1]
-        fifth_last_sample = self.keypoints_data[-5]
+        tenth_last_sample = self.keypoints_data[-10]
         y1, _, c1 = last_sample.get(BP.LEFT_SHOULDER)
-        y2, _, c2 = fifth_last_sample.get(BP.LEFT_SHOULDER)
+        y2, _, c2 = tenth_last_sample.get(BP.LEFT_SHOULDER)
         if c1 < 0.3 or c2 < 0.3:
             return False
-        return y1 - y2 >= 0.1
+        return y1 - y2 >= 0.2
 
     def _player_out_of_frame(self) -> bool:
         """ Determine if player is out of frame
         Current condition: 
-          Shoulders must be in frame within the last 3 samples
+          Shoulders must be in frame within the last 5 samples
         Returns:
           True if player is out-of-frame; False o.w.
         """

--- a/Movenet/src/publisher.py
+++ b/Movenet/src/publisher.py
@@ -38,7 +38,11 @@ class Publisher(mqtt.Client):
             self.publish(topic, "d", qos=1)
         elif player_pos == Position.OUT_OF_FRAME:
             self.publish(topic, "o", qos=1)
-        elif player_pos == Position.STATIONARY:
+        # transition from duck/or out-of-frame to stationary
+        elif (
+            player_pos == Position.DUCK_STATIONARY
+            or player_pos == Position.OUT_FRAME_STATIONARY
+        ):
             self.publish(topic, "s", qos=1)
 
     # connect/disconnect functions


### PR DESCRIPTION
Changes
- add states to send return to stationary for duck/out-of-frame
- reduce stationary_recognized threshold to prevent duck-up/jump-down being recognized as duck/jump
- increase rate thresholds for jump/duck to prevent player drift from being recognized as jump/duck