### PR TITLE
store level number for end scene

### DIFF
--- a/Unity/Assets/Scripts/Timer.cs
+++ b/Unity/Assets/Scripts/Timer.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.SceneManagement;
 
 public class Timer : MonoBehaviour
 {
@@ -29,6 +30,8 @@ public class Timer : MonoBehaviour
 
     void OnDisable()
     {
+        Scene scene = SceneManager.GetActiveScene();
+        PlayerPrefs.SetString("PrevScene", scene.name);
         PlayerPrefs.SetFloat("finalTime", timeVal);
     }
 }


### PR DESCRIPTION
The level name is stored and can be accessed in the final scene
make a variable 
string level = PlayerPrefs.GetString("PrevScene");
in whatever script you want to use it.