### PR TITLE
Run movenet executable from Unity

### DIFF
--- a/Movenet/.gitignore
+++ b/Movenet/.gitignore
@@ -12,3 +12,9 @@ __pycache__
 
 # personal
 subscriber.py
+
+# executable
+position_tracking
+dist/
+build/
+*.spec

--- a/Movenet/src/movenet.py
+++ b/Movenet/src/movenet.py
@@ -67,16 +67,16 @@ class Movenet(object):
           model_name(str): Name of the TFLite MoveNet model.
         """
         if model_name == "lightning":
-            self._interpreter = tf.lite.Interpreter(
-                model_path="../models/lite-model_movenet_singlepose_lightning_3.tflite",
-                num_threads=4,
-            )
+            # model_path = "../models/lite-model_movenet_singlepose_lightning_3.tflite"
+            model_path = "../Movenet/models/lite-model_movenet_singlepose_lightning_3.tflite"
         else:
-            self._interpreter = tf.lite.Interpreter(
-                "../models/lite-model_movenet_singlepose_thunder_3.tflite",
+            # model_path = "../models/lite-model_movenet_singlepose_thunder_3.tflite"
+            model_path = "../Movenet/models/lite-model_movenet_singlepose_thunder_3.tflite"
+        
+        self._interpreter = tf.lite.Interpreter(
+                model_path=model_path,
                 num_threads=4,
             )
-
         self._interpreter.allocate_tensors()
 
         self._input_index = self._interpreter.get_input_details()[0]["index"]

--- a/Setup_Scripts/build_movenet
+++ b/Setup_Scripts/build_movenet
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Build movenet executable to execute from Unity
+# Ensure to activate conda env before running
+# This may take a few mins...
+MOVENET_DIR=../Movenet/src
+cd $MOVENET_DIR
+
+# build single executable with all dependencies installed
+pyinstaller -F --onefile position_tracking.py
+# executable must be in directory Movenet/src
+# due to relative model paths
+cd dist
+mv position_tracking ..

--- a/Setup_Scripts/build_movenet
+++ b/Setup_Scripts/build_movenet
@@ -7,8 +7,4 @@ MOVENET_DIR=../Movenet/src
 cd $MOVENET_DIR
 
 # build single executable with all dependencies installed
-pyinstaller -F --onefile position_tracking.py
-# executable must be in directory Movenet/src
-# due to relative model paths
-cd dist
-mv position_tracking ..
+pyinstaller -D position_tracking.py

--- a/Setup_Scripts/build_movenet.bat
+++ b/Setup_Scripts/build_movenet.bat
@@ -9,4 +9,4 @@ pyinstaller -F --onefile position_tracking.py
 :: executable must be in directory Movenet/src
 :: due to relative model paths
 cd dist
-move position_tracking ..
+move position_tracking.exe ..

--- a/Setup_Scripts/build_movenet.bat
+++ b/Setup_Scripts/build_movenet.bat
@@ -1,0 +1,12 @@
+:: Build movenet executable to execute from Unity
+:: Ensure to activate conda env before running
+:: This may take a few mins...
+set MOVENET_DIR=..\Movenet\src
+cd %MOVENET_DIR%
+
+:: build single executable with all dependencies installed
+pyinstaller -F --onefile position_tracking.py
+:: executable must be in directory Movenet/src
+:: due to relative model paths
+cd dist
+move position_tracking ..

--- a/Setup_Scripts/build_movenet.bat
+++ b/Setup_Scripts/build_movenet.bat
@@ -5,8 +5,4 @@ set MOVENET_DIR=..\Movenet\src
 cd %MOVENET_DIR%
 
 :: build single executable with all dependencies installed
-pyinstaller -F --onefile position_tracking.py
-:: executable must be in directory Movenet/src
-:: due to relative model paths
-cd dist
-move position_tracking.exe ..
+pyinstaller -D position_tracking.py

--- a/Setup_Scripts/movenet_requirements.txt
+++ b/Setup_Scripts/movenet_requirements.txt
@@ -3,3 +3,4 @@ paho-mqtt==1.5.1
 tensorflow==2.6.1
 tensorflow-estimator==2.6.0
 opencv-python==4.5.3.56
+pyinstaller==4.8

--- a/Unity/Assets/Scripts/RunPython.cs
+++ b/Unity/Assets/Scripts/RunPython.cs
@@ -33,20 +33,20 @@ public class RunPython : MonoBehaviour
                 // Executable path for Windows machines only
                 #if UNITY_STANDALONE_WIN
                 UnityEngine.Debug.Log("Using Windows Script");
-                psi.FileName =  path + "\\..\\..\\..\\Movenet\\src\\position_tracking.exe";
+                psi.FileName =  path + "\\..\\..\\..\\Movenet\\src\\dist\\position_tracking\\position_tracking.exe";
                 #endif
                 // Executable path for Mac only
                 #if UNITY_STANDALONE_OSX
                 UnityEngine.Debug.Log("Using Mac Script");
-                psi.FileName = "../Movenet/src/position_tracking";
+                psi.FileName = "../Movenet/src/dist/position_tracking/position_tracking";
                 #endif
 
                 // Paths for development
                 #if UNITY_EDITOR_WIN
-                psi.FileName =  path + "\\..\\..\\Movenet\\src\\position_tracking.exe";
+                psi.FileName =  path + "\\..\\..\\Movenet\\src\\dist\\position_tracking\\position_tracking.exe";
                 #endif
                 #if UNITY_EDITOR_OSX
-                psi.FileName = "../Movenet/src/position_tracking";
+                psi.FileName = "../Movenet/src/dist/position_tracking/position_tracking";
                 #endif
 
 

--- a/Unity/Assets/Scripts/RunPython.cs
+++ b/Unity/Assets/Scripts/RunPython.cs
@@ -33,23 +33,26 @@ public class RunPython : MonoBehaviour
                 // Uses LaunchGame.bat on WIndows machines only
                 #if UNITY_STANDALONE_WIN
                 UnityEngine.Debug.Log("Using Windows Script");
-                psi.FileName = "..\\Setup_Scripts\\LaunchGame.bat";
-                psi.UseShellExecute = false;
-                psi.RedirectStandardOutput = true;
+                psi.FileName = "..\\Movenet\\src\\position_tracking";
                 #endif
                 // Uses LaunchGame on Mac only
                 #if UNITY_STANDALONE_OSX
                 UnityEngine.Debug.Log("Using Mac Script");
-                psi.FileName = "../Setup_Scripts/LaunchGame";
-                psi.UseShellExecute = true;
+                psi.FileName = "../Movenet/src/position_tracking";
                 #endif
-                
-                psi.Arguments = username;
+
+                psi.UseShellExecute = false;
+                psi.RedirectStandardOutput = true;
+                psi.RedirectStandardError = true;
                 psi.CreateNoWindow = true;
+                psi.Arguments = "--username " + username;
 
                 Process p = Process.Start(psi);
-                string strOutput = p.StandardOutput.ReadToEnd();
-                
+                p.ErrorDataReceived += onError;
+                // printing pose output overloads console
+                // p.OutputDataReceived += onOutput;
+                p.BeginErrorReadLine();
+                p.BeginOutputReadLine();
 
             }
             catch (Exception e)
@@ -58,5 +61,13 @@ public class RunPython : MonoBehaviour
             }
         }
         );
+    }
+    // log stdout/stderr for debugging purposes
+     private void onOutput(object sender, DataReceivedEventArgs e) {
+        UnityEngine.Debug.Log(e.Data);
+    }
+
+    private void onError(object sender, DataReceivedEventArgs e) {
+        UnityEngine.Debug.Log(e.Data);
     }
 }

--- a/Unity/Assets/Scripts/RunPython.cs
+++ b/Unity/Assets/Scripts/RunPython.cs
@@ -20,10 +20,10 @@ public class RunPython : MonoBehaviour
     void Start()
     {
         string username = PlayerPrefs.GetString("Username");
-        RunMovenet(username);
+        RunMovenet(username, Application.dataPath);
     }
 
-    async public void RunMovenet(string username)
+    async public void RunMovenet(string username, string path)
     {
         await Task.Run(() =>
         {
@@ -33,7 +33,7 @@ public class RunPython : MonoBehaviour
                 // Uses LaunchGame.bat on WIndows machines only
                 #if UNITY_STANDALONE_WIN
                 UnityEngine.Debug.Log("Using Windows Script");
-                psi.FileName = "..\\Movenet\\src\\position_tracking";
+                psi.FileName =  path + "\\..\\..\\Movenet\\src\\position_tracking.exe";
                 #endif
                 // Uses LaunchGame on Mac only
                 #if UNITY_STANDALONE_OSX

--- a/Unity/Assets/Scripts/RunPython.cs
+++ b/Unity/Assets/Scripts/RunPython.cs
@@ -30,16 +30,25 @@ public class RunPython : MonoBehaviour
             try
             {
                 ProcessStartInfo psi = new ProcessStartInfo();
-                // Uses LaunchGame.bat on WIndows machines only
+                // Executable path for Windows machines only
                 #if UNITY_STANDALONE_WIN
                 UnityEngine.Debug.Log("Using Windows Script");
-                psi.FileName =  path + "\\..\\..\\Movenet\\src\\position_tracking.exe";
+                psi.FileName =  path + "\\..\\..\\..\\Movenet\\src\\position_tracking.exe";
                 #endif
-                // Uses LaunchGame on Mac only
+                // Executable path for Mac only
                 #if UNITY_STANDALONE_OSX
                 UnityEngine.Debug.Log("Using Mac Script");
                 psi.FileName = "../Movenet/src/position_tracking";
                 #endif
+
+                // Paths for development
+                #if UNITY_EDITOR_WIN
+                psi.FileName =  path + "\\..\\..\\Movenet\\src\\position_tracking.exe";
+                #endif
+                #if UNITY_EDITOR_OSX
+                psi.FileName = "../Movenet/src/position_tracking";
+                #endif
+
 
                 psi.UseShellExecute = false;
                 psi.RedirectStandardOutput = true;


### PR DESCRIPTION
## Changes
Compile Movenet executable in directory (instead of one-file) mode to improve program startup time.

## Issues
For some reason, Unity is having bugs with MQTT. Either an exception is being thrown (see below) or the jump/duck messages have significant lag (~10 secs). I think this has something to with the MQTT broker instead of the executable since it's doing the same thing one-file/directory mode and was working fine in our previous PR.

```
MqttCommunicationException: Exception of type 'uPLibrary.Networking.M2Mqtt.Exceptions.MqttCommunicationException' was thrown.
uPLibrary.Networking.M2Mqtt.MqttClient.SendReceive (System.Byte[] msgBytes, System.Int32 timeout) (at <0f498b903ed9490e9718f3f579c8c9b3>:0)
uPLibrary.Networking.M2Mqtt.MqttClient.SendReceive (uPLibrary.Networking.M2Mqtt.Messages.MqttMsgBase msg, System.Int32 timeout) (at <0f498b903ed9490e9718f3f579c8c9b3>:0)
uPLibrary.Networking.M2Mqtt.MqttClient.SendReceive (uPLibrary.Networking.M2Mqtt.Messages.MqttMsgBase msg) (at <0f498b903ed9490e9718f3f579c8c9b3>:0)
uPLibrary.Networking.M2Mqtt.MqttClient.Connect (System.String clientId, System.String username, System.String password, System.Boolean willRetain, System.Byte willQosLevel, System.Boolean willFlag, System.String willTopic, System.String willMessage, System.Boolean cleanSession, System.UInt16 keepAlivePeriod) (at <0f498b903ed9490e9718f3f579c8c9b3>:0)
uPLibrary.Networking.M2Mqtt.MqttClient.Connect (System.String clientId) (at <0f498b903ed9490e9718f3f579c8c9b3>:0)
mqtt.Start () (at Assets/Scripts/mqtt.cs:48)
```

## Test
```
cd Setup_Scripts
./build_movenet
# launch unity in editor/build mode
```

Note: do not merge, for testing purposes only.